### PR TITLE
60 exposer le signalement via lapi

### DIFF
--- a/app/Http/Controllers/Api/v1/ApiReportController.php
+++ b/app/Http/Controllers/Api/v1/ApiReportController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use App\Models\Report;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ApiReportController extends Controller
+{
+    public function store(Request $request, Post $post)
+    {
+        $validated = $request->validate([
+            "reason" => "nullable|string|max:255",
+        ]);
+
+        // Vérifie si l'utilisateur a déjà signalé ce post
+        $alreadyReported = Report::where("post_id", $post->id)
+            ->where("user_id", Auth::id())
+            ->exists();
+
+        if ($alreadyReported) {
+            return response()->json(
+                [
+                    "message" => __("ui.reports.already_reported"),
+                ],
+                409,
+            );
+        }
+
+        $report = new Report();
+        $report->post_id = $post->id;
+        $report->user_id = Auth::id();
+        $report->reason = $validated["reason"] ?? null;
+        $report->save();
+
+        return response()->json(
+            [
+                "message" => __("ui.reports.reported"),
+            ],
+            201,
+        );
+    }
+}

--- a/bruno-collection/requests/Report a post.yml
+++ b/bruno-collection/requests/Report a post.yml
@@ -1,0 +1,26 @@
+info:
+  name: Report a post
+  type: http
+  seq: 6
+
+http:
+  method: POST
+  url: http://localhost:8000/api/v1/posts/1/report
+  headers:
+    - name: Authorization
+      value: Bearer <token>
+    - name: Accept
+      value: application/json
+  body:
+    type: json
+    data: |-
+      {
+        "reason": "Ce post contient du contenu inapproprié."
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,10 +3,14 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\v1\ApiPostController;
+use App\Http\Controllers\Api\v1\ApiReportController;
 
 Route::get("/user", function (Request $request) {
     return $request->user();
 })->middleware("auth:sanctum");
+
+Route::post('/v1/posts/{post}/report', [ApiReportController::class, 'store'])
+    ->middleware('auth:sanctum');
 
 Route::apiResource("v1/posts", ApiPostController::class)
     ->middlewareFor(["index", "show"], ["auth:sanctum", "abilities:posts:read"])


### PR DESCRIPTION
permet à un client externe de créer un signalement sur un post, exactement comme si quelqu'un faisiant un signalement en cliquant sur le bouton. 

(dans l'idée ou des admins aurait une app mobile/serv discord qui recense tout) 